### PR TITLE
Update URLs in manifest, bump version 0.1.7

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,6 +1,6 @@
 # DaxLib.Sample
 
-A brief description of the package.
+This is a sample DAX library for demonstration purposes.
 
 ## Usage
 
@@ -17,7 +17,7 @@ EVALUATE
 
 ## Contributing
 
-Contributions are welcome! Please open issues or submit pull requests on GitHub.
+Contributions are welcome! Please open issues or submit pull requests on https://github.com/sql-bi/dev-daxlib-sample
 
 ## License
 

--- a/src/lib/functions.tmdl
+++ b/src/lib/functions.tmdl
@@ -3,7 +3,7 @@ function 'DaxLib.Sample.MyFunc1' = () => 1
 
 	annotation DAXLIB_PackageId = DaxLib.Sample
 
-	annotation DAXLIB_PackageVersion = 0.1.6
+	annotation DAXLIB_PackageVersion = 0.1.7
 
 /// MyFunc2 description
 function 'DaxLib.Sample.MyFunc2' =
@@ -15,7 +15,7 @@ function 'DaxLib.Sample.MyFunc2' =
 
 	annotation DAXLIB_PackageId = DaxLib.Sample
 
-	annotation DAXLIB_PackageVersion = 0.1.6
+	annotation DAXLIB_PackageVersion = 0.1.7
 
 /// MyFunc3 description
 function 'DaxLib.Sample.MyFunc3' =
@@ -29,4 +29,4 @@ function 'DaxLib.Sample.MyFunc3' =
 
 	annotation DAXLIB_PackageId = DaxLib.Sample
 
-	annotation DAXLIB_PackageVersion = 0.1.6
+	annotation DAXLIB_PackageVersion = 0.1.7

--- a/src/manifest.daxlib
+++ b/src/manifest.daxlib
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/sql-bi/daxlib/refs/heads/main/schemas/manifest/1.0.0/manifest.1.0.0.schema.json",
   "id": "DaxLib.Sample",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "authors": "SQLBI,albertospelta",
   "description": "DaxLib sample library",
   "tags": "DAX,SAMPLE",

--- a/src/manifest.daxlib
+++ b/src/manifest.daxlib
@@ -5,8 +5,8 @@
   "authors": "SQLBI,albertospelta",
   "description": "DaxLib sample library",
   "tags": "DAX,SAMPLE",
-  "releaseNotes": "Added README.md",
-  "projectUrl": "https://github.com/sql-bi/daxlib",
-  "repositoryUrl": "https://github.com/sql-bi/daxlib/tree/main/packages/d/daxlib.sample",
+  "releaseNotes": "Update metadata with new project and repository URLs",
+  "projectUrl": "https://github.com/sql-bi/dev-daxlib-sample",
+  "repositoryUrl": "https://github.com/sql-bi/dev-daxlib-sample",
   "readme": "/README.md"
 }


### PR DESCRIPTION
This pull request updates the `DaxLib.Sample` package to version 0.1.7 and improves its documentation and metadata to reflect the new project and repository URLs. The most important changes are grouped below:

Package metadata updates:

* Updated the package version from `0.1.6` to `0.1.7` in `src/manifest.daxlib` and all function annotations in `src/lib/functions.tmdl`. [[1]](diffhunk://#diff-e8e9061fd9fea94ec087c34605f1b9f1060fb65d0d9e386b2074edca2d03f1d8L4-R10) [[2]](diffhunk://#diff-b6a43afcc77a6647b4be2efbede400b19c8ae2405069a10e088d2ba6e62760b4L6-R6) [[3]](diffhunk://#diff-b6a43afcc77a6647b4be2efbede400b19c8ae2405069a10e088d2ba6e62760b4L18-R18) [[4]](diffhunk://#diff-b6a43afcc77a6647b4be2efbede400b19c8ae2405069a10e088d2ba6e62760b4L32-R32)
* Changed the `projectUrl` and `repositoryUrl` fields in `src/manifest.daxlib` to point to `https://github.com/sql-bi/dev-daxlib-sample`.
* Updated the `releaseNotes` in `src/manifest.daxlib` to mention the metadata update.

Documentation improvements:

* Revised the package description in `src/README.md` to clarify its purpose as a sample DAX library.
* Updated the contributing section in `src/README.md` to direct contributors to the new GitHub repository.